### PR TITLE
+ banner for minified file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,9 @@ module.exports = function(grunt) {
 		},
 		
 		uglify: {
+			options: {
+				banner: '/*! <%= pkg.name %> <%= pkg.version %> (c)2014 hoxton-one, with parts (c)2014 Joyent and contributers  @licence <%= pkg.licence %>*/\n'
+				},
 			dist: {
 				files: {
 					'dist/deepstream.min.js': [ 'dist/deepstream.js' ]


### PR DESCRIPTION
Reasoning: files often concocted (use: [jsDelivr CDN](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request), so you'll lose file ID/name & copyright.

Should work, but untested.